### PR TITLE
Enables machine actions and account API key creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Release — Build and Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish to npm
+        if: ${{ github.event_name == 'release' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+

--- a/nodes/VastAiNode/Accounts/CreateApiKey.ts
+++ b/nodes/VastAiNode/Accounts/CreateApiKey.ts
@@ -1,0 +1,5 @@
+export const createApiKeyParams = [
+	{ name: 'Name', value: 'name' },
+	{ name: 'Permissions', value: 'permissions' },
+	{ name: 'Key Params', value: 'key_params' },
+];

--- a/nodes/VastAiNode/Machines/CancelMaint.ts
+++ b/nodes/VastAiNode/Machines/CancelMaint.ts
@@ -1,0 +1,4 @@
+// search_offers.ts
+export const cancelMaintParams = [
+  { name: 'Machine ID', value: 'machine_id' },
+];

--- a/nodes/VastAiNode/Machines/CancelMaint.ts
+++ b/nodes/VastAiNode/Machines/CancelMaint.ts
@@ -1,4 +1,3 @@
-// search_offers.ts
 export const cancelMaintParams = [
   { name: 'Machine ID', value: 'machine_id' },
 ];

--- a/nodes/VastAiNode/Machines/CleanupMachine.ts
+++ b/nodes/VastAiNode/Machines/CleanupMachine.ts
@@ -1,0 +1,4 @@
+// search_offers.ts
+export const cleanupMachineParams = [
+  { name: 'Machine ID', value: 'machine_id' },
+];

--- a/nodes/VastAiNode/Machines/ListMachine.ts
+++ b/nodes/VastAiNode/Machines/ListMachine.ts
@@ -1,0 +1,12 @@
+// search_offers.ts
+export const listMachineParams = [
+  { name: 'Machine', value: 'machine' },
+  { name: 'Price Gpu', value: 'price_gpu' },
+  { name: 'Price Disk', value: 'price_disk' },
+  { name: 'Price Inetu', value: 'price_inetu' },
+  { name: 'Price Inetd', value: 'price_inetd' },
+  { name: 'Price Min Bid', value: 'price_min_bid' },
+  { name: 'Min Chunk', value: 'min_chunk' },
+  { name: 'End Date', value: 'end_date' },
+  { name: 'Credit Discount Max', value: 'credit_discount_max' },
+];

--- a/nodes/VastAiNode/Machines/ListMachine.ts
+++ b/nodes/VastAiNode/Machines/ListMachine.ts
@@ -1,4 +1,3 @@
-// search_offers.ts
 export const listMachineParams = [
   { name: 'Machine', value: 'machine' },
   { name: 'Price Gpu', value: 'price_gpu' },

--- a/nodes/VastAiNode/Machines/RemoveDefjob.ts
+++ b/nodes/VastAiNode/Machines/RemoveDefjob.ts
@@ -1,3 +1,3 @@
-export const cleanupMachineParams = [
+export const removeDefjobParams = [
   { name: 'Machine ID', value: 'machine_id' },
 ];

--- a/nodes/VastAiNode/Machines/ScheduleMaint.ts
+++ b/nodes/VastAiNode/Machines/ScheduleMaint.ts
@@ -1,0 +1,7 @@
+export const scheduleMaintParams = [
+  { name: 'Machine ID', value: 'machine_id' },
+  { name: 'Start Date', value: 'sdate' },
+  { name: 'Duration', value: 'duration' },
+  { name: 'Maintenance Reason', value: 'maintenance_reason' },
+  { name: 'Maintenance Category', value: 'maintenance_category' },
+];

--- a/nodes/VastAiNode/Machines/SetDefjob.ts
+++ b/nodes/VastAiNode/Machines/SetDefjob.ts
@@ -1,0 +1,8 @@
+export const setDefjobParams = [
+  { name: 'Machine', value: 'machine' },
+  { name: 'GPU Price', value: 'price_gpu' },
+  { name: 'Internet Up Price', value: 'price_inetu' },
+  { name: 'Internet Down Price', value: 'price_inetd' },
+  { name: 'Image', value: 'image' },
+  { name: 'Arguments', value: 'args' },
+];

--- a/nodes/VastAiNode/Machines/ShowMachines.ts
+++ b/nodes/VastAiNode/Machines/ShowMachines.ts
@@ -1,0 +1,3 @@
+export const showMachinesParams = [
+  { name: 'User ID', value: 'user_id' },
+];

--- a/nodes/VastAiNode/Machines/ShowReports.ts
+++ b/nodes/VastAiNode/Machines/ShowReports.ts
@@ -1,3 +1,3 @@
-export const cleanupMachineParams = [
+export const showReportsParams = [
   { name: 'Machine ID', value: 'machine_id' },
 ];

--- a/nodes/VastAiNode/Machines/UnlistMachine.ts
+++ b/nodes/VastAiNode/Machines/UnlistMachine.ts
@@ -1,3 +1,3 @@
-export const cleanupMachineParams = [
+export const unlistMachineParams = [
   { name: 'Machine ID', value: 'machine_id' },
 ];

--- a/nodes/VastAiNode/Machines/setMinBid.ts
+++ b/nodes/VastAiNode/Machines/setMinBid.ts
@@ -1,0 +1,4 @@
+export const setMinBidParams = [
+  { name: 'Machine ID', value: 'machine_id' },
+  { name: 'Price', value: 'price' },
+];

--- a/nodes/VastAiNode/VastAiNode.node.ts
+++ b/nodes/VastAiNode/VastAiNode.node.ts
@@ -38,6 +38,9 @@ import { deleteVolumeParams } from './Volumes/DeleteVolume';
 import { rentVolumeParams } from './Volumes/RentVolume';
 import { searchVolumesParams } from './Volumes/SearchVolumes';
 import { unlistVolumeParams } from './Volumes/UnlistVolume';
+import { cancelMaintParams } from './Machines/CancelMaint';
+import { cleanupMachineParams } from './Machines/CleanupMachine';
+import { listMachineParams } from './Machines/ListMachine';
 
 interface ApiEndpoint {
 	endpoint: string;
@@ -76,7 +79,7 @@ export class VastAiNode implements INodeType {
 					{ name: 'Accounts', value: 'accounts' },
 					{ name: 'Billing', value: 'billing' },
 					{ name: 'Instances', value: 'instances' },
-					// { name: 'Machines', value: 'machines' },
+					{ name: 'Machines', value: 'machines' },
 					{ name: 'Search', value: 'search' },
 					{ name: 'Serverless', value: 'serverless' },
 					// { name: 'Team', value: 'team' },
@@ -160,9 +163,9 @@ export class VastAiNode implements INodeType {
 						];
 					case 'machines':
 						return [
-							// { name: 'Cancel Maint', value: 'cancel_maint_put' },
-							// { name: 'Cleanup Machine', value: 'cleanup_machine_put' },
-							// { name: 'List Machine', value: 'list_machine_put' },
+							{ name: 'Cancel Maint', value: 'cancel_maint_put' },
+							{ name: 'Cleanup Machine', value: 'cleanup_machine_put' },
+							{ name: 'List Machine', value: 'list_machine_put' },
 							// { name: 'Remove Defjob', value: 'remove_defjob_delete' },
 							// { name: 'Schedule Maint', value: 'schedule_maint_put' },
 							// { name: 'Set Defjob', value: 'set_defjob_put' },
@@ -295,11 +298,11 @@ export class VastAiNode implements INodeType {
 
 					// Machines cases
 					case 'cancel_maint_put':
-						return [];
+						return cancelMaintParams;
 					case 'cleanup_machine_put':
-						return [];
+						return cleanupMachineParams;
 					case 'list_machine_put':
-						return [];
+						return listMachineParams;
 					case 'remove_defjob_delete':
 						return [];
 					case 'show_reports_get':
@@ -505,9 +508,9 @@ export class VastAiNode implements INodeType {
 			"show_ssh_keys_get": { endpoint: "/instances/{instance_id}/ssh/", method: "GET" },
 
 			// Machines
-			"cancel_maint_put": { endpoint: "", method: "PUT" },
-			"cleanup_machine_put": { endpoint: "", method: "PUT" },
-			"list_machine_put": { endpoint: "", method: "PUT" },
+			"cancel_maint_put": { endpoint: "/machines/{machine_id}/cancel_maint", method: "PUT" },
+			"cleanup_machine_put": { endpoint: "/machines/{machine_id}/cleanup", method: "PUT" },
+			"list_machine_put": { endpoint: "/machines/create_asks/", method: "PUT" },
 			"remove_defjob_delete": { endpoint: "", method: "DELETE" },
 			"schedule_maint_put": { endpoint: "", method: "PUT" },
 			"set_defjob_put": { endpoint: "", method: "PUT" },
@@ -795,6 +798,24 @@ export class VastAiNode implements INodeType {
 					case 'unlist_volume_post':
 						{
 							requestOptions.body = { body: requestBody };
+							break;
+						}
+					case 'cancel_maint_put':
+						{
+							let machine_id = queryParams.machine_id;
+							if (machine_id == null || machine_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
+							break;
+						}
+					case 'cleanup_machine_put':
+						{
+							let machine_id = queryParams.machine_id;
+							if (machine_id == null || machine_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
 							break;
 						}
 					default:

--- a/nodes/VastAiNode/VastAiNode.node.ts
+++ b/nodes/VastAiNode/VastAiNode.node.ts
@@ -41,6 +41,13 @@ import { unlistVolumeParams } from './Volumes/UnlistVolume';
 import { cancelMaintParams } from './Machines/CancelMaint';
 import { cleanupMachineParams } from './Machines/CleanupMachine';
 import { listMachineParams } from './Machines/ListMachine';
+import { removeDefjobParams } from './Machines/RemoveDefjob';
+import { showReportsParams } from './Machines/ShowReports';
+import { scheduleMaintParams } from './Machines/ScheduleMaint';
+import { setDefjobParams } from './Machines/SetDefjob';
+import { setMinBidParams } from './Machines/setMinBid';
+import { showMachinesParams } from './Machines/ShowMachines';
+import { unlistMachineParams } from './Machines/UnlistMachine';
 
 interface ApiEndpoint {
 	endpoint: string;
@@ -166,13 +173,13 @@ export class VastAiNode implements INodeType {
 							{ name: 'Cancel Maint', value: 'cancel_maint_put' },
 							{ name: 'Cleanup Machine', value: 'cleanup_machine_put' },
 							{ name: 'List Machine', value: 'list_machine_put' },
-							// { name: 'Remove Defjob', value: 'remove_defjob_delete' },
-							// { name: 'Schedule Maint', value: 'schedule_maint_put' },
-							// { name: 'Set Defjob', value: 'set_defjob_put' },
-							// { name: 'Set Min Bid', value: 'set_min_bid_put' },
-							// { name: 'Show Machines', value: 'show_machines_get' },
-							// { name: 'Show Reports', value: 'show_reports_get' },
-							// { name: 'Unlist Machine', value: 'unlist_machine_delete' },
+							{ name: 'Remove Defjob', value: 'remove_defjob_delete' },
+							{ name: 'Schedule Maint', value: 'schedule_maint_put' },
+							{ name: 'Set Defjob', value: 'set_defjob_put' },
+							{ name: 'Set Min Bid', value: 'set_min_bid_put' },
+							{ name: 'Show Machines', value: 'show_machines_get' },
+							{ name: 'Show Reports', value: 'show_reports_get' },
+							{ name: 'Unlist Machine', value: 'unlist_machine_delete' },
 						];
 					case 'accounts':
 						return [
@@ -304,19 +311,19 @@ export class VastAiNode implements INodeType {
 					case 'list_machine_put':
 						return listMachineParams;
 					case 'remove_defjob_delete':
-						return [];
+						return removeDefjobParams;
 					case 'show_reports_get':
-						return [];
+						return showReportsParams;
 					case 'schedule_maint_put':
-						return [];
+						return scheduleMaintParams;
 					case 'set_defjob_put':
-						return [];
+						return setDefjobParams;
 					case 'set_min_bid_put':
-						return [];
+						return setMinBidParams;
 					case 'show_machines_get':
-						return [];
+						return showMachinesParams;
 					case 'unlist_machine_delete':
-						return [];
+						return unlistMachineParams;
 
 					// Accounts cases
 					case 'create_api_key_post':
@@ -511,13 +518,13 @@ export class VastAiNode implements INodeType {
 			"cancel_maint_put": { endpoint: "/machines/{machine_id}/cancel_maint", method: "PUT" },
 			"cleanup_machine_put": { endpoint: "/machines/{machine_id}/cleanup", method: "PUT" },
 			"list_machine_put": { endpoint: "/machines/create_asks/", method: "PUT" },
-			"remove_defjob_delete": { endpoint: "", method: "DELETE" },
-			"schedule_maint_put": { endpoint: "", method: "PUT" },
-			"set_defjob_put": { endpoint: "", method: "PUT" },
-			"set_min_bid_put": { endpoint: "", method: "PUT" },
-			"show_machines_get": { endpoint: "", method: "GET" },
-			"show_reports_get": { endpoint: "", method: "GET" },
-			"unlist_machine_delete": { endpoint: "", method: "DELETE" },
+			"remove_defjob_delete": { endpoint: "/machines/{machine_id}/defjob", method: "DELETE" },
+			"schedule_maint_put": { endpoint: "/machines/{machine_id}/dnotify", method: "PUT" },
+			"set_defjob_put": { endpoint: "/machines/create_bids/", method: "PUT" },
+			"set_min_bid_put": { endpoint: "/machines/{machine_id}/minbid", method: "PUT" },
+			"show_machines_get": { endpoint: "/machines/", method: "GET" },
+			"show_reports_get": { endpoint: "/machines/{machine_id}/reports", method: "GET" },
+			"unlist_machine_delete": { endpoint: "/machines/{machine_id}/asks", method: "DELETE" },
 
 			// Search
 			"search_benchmarks_get": { endpoint: "/benchmarks/", method: "GET" },
@@ -754,22 +761,22 @@ export class VastAiNode implements INodeType {
 						}
 					case 'show_earnings_get':
 						{
-							const { user_id, ...rest } = queryParams;
+							const user_id = queryParams.user_id;
 							if (user_id == null || user_id === '') {
 								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: user_id', { itemIndex });
 							}
 							requestOptions.url = requestOptions.url.replace('{user_id}', encodeURIComponent(String(user_id)));
-							requestOptions.qs = rest;
+							requestOptions.qs = requestBody;
 							break;
 						}
 					case 'show_invoice_get':
 						{
-							const { user_id, ...rest } = queryParams;
+							const user_id = queryParams.user_id;
 							if (user_id == null || user_id === '') {
 								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: user_id', { itemIndex });
 							}
 							requestOptions.url = requestOptions.url.replace('{user_id}', encodeURIComponent(String(user_id)));
-							requestOptions.qs = rest;
+							requestOptions.qs = requestBody;
 							break;
 						}
 					case 'delete_volume_delete':
@@ -802,7 +809,7 @@ export class VastAiNode implements INodeType {
 						}
 					case 'cancel_maint_put':
 						{
-							let machine_id = queryParams.machine_id;
+							let machine_id = requestBody.machine_id;
 							if (machine_id == null || machine_id === '') {
 								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
 							}
@@ -811,7 +818,63 @@ export class VastAiNode implements INodeType {
 						}
 					case 'cleanup_machine_put':
 						{
+							let machine_id = requestBody.machine_id;
+							if (machine_id == null || machine_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
+							break;
+						}
+					case 'remove_defjob_delete':
+						{
+							let machine_id = requestBody.machine_id;
+							if (machine_id == null || machine_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
+							break;
+						}
+					case 'show_reports_get':
+						{
 							let machine_id = queryParams.machine_id;
+							if (machine_id == null || machine_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
+							break;
+						}
+					case 'schedule_maint_put':
+						{
+							let {machine_id, ...rest} = requestBody;
+							if (machine_id == null || machine_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
+							requestOptions.body = rest;
+							break;
+						}
+					case 'set_min_bid_put':
+						{
+							let {machine_id, ...rest} = requestBody;
+							if (machine_id == null || machine_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
+							requestOptions.body = rest;
+							break;
+						}
+					case 'show_machines_get':
+						{
+							let user_id = queryParams.user_id;
+							if (user_id == null || user_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: user_id', { itemIndex });
+							}
+							requestOptions.qs = queryParams;
+							break;
+						}
+					case 'unlist_machine_delete':
+						{
+							let machine_id = requestBody.machine_id;
 							if (machine_id == null || machine_id === '') {
 								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
 							}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-vast.ai",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Using the Vast.AI API in an n8n environment.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
### Summary

This pull request enables several machine management functionalities within the Vast.ai node and adds the ability to create API keys for accounts. It introduces new API endpoints and parameter definitions to facilitate these features, enhancing the node's capabilities.

### Motivation

The addition of machine actions and account API key creation provides users with greater control over their Vast.ai resources and accounts directly from the node. This allows for more streamlined management and automation of tasks related to machines and account security.

### Changes

-   Adds a new GitHub workflow to notify Telegram channels on releases and tags.
-   Enables the "Machines" option in the node configuration.
-   Implements API endpoints for machine actions such as cancel maintenance, cleanup machine, list machine, remove defjob, schedule maintenance, set defjob, set min bid, show machines, show reports, and unlist machine.
-   Adds the "Create API Key" functionality for accounts.
-   Defines parameters for each of the new API endpoints.
-   Adds parsing of JSON strings to enable complex values for parameters.

### Testing

-   [ ] Included unit tests to verify the functionality.
-   [ ] Manually tested the new API endpoints to ensure they function as expected.
-   [ ] Tested the Telegram notification workflow.

### Related Issues