### PR TITLE
Ensure Telegram workflow writes string output

### DIFF
--- a/.github/workflows/telegram-release.yml
+++ b/.github/workflows/telegram-release.yml
@@ -47,24 +47,30 @@ jobs:
             release_name = release.get("name") or release.get("tag_name")
             tag_name = release.get("tag_name")
             html_url = release.get("html_url")
-            message = (
-              "🚀 New release published\n"
-              f"Repository: {repository}\n"
-              f"Release: {release_name}\n"
-              f"Tag: {tag_name}\n"
-              f"Published by: {actor}\n"
-              f"Details: {html_url}"
+            # Use explicit join to guarantee a single string payload for GitHub Actions outputs.
+            message = "".join(
+              (
+                "🚀 New release published\n",
+                f"Repository: {repository}\n",
+                f"Release: {release_name}\n",
+                f"Tag: {tag_name}\n",
+                f"Published by: {actor}\n",
+                f"Details: {html_url}",
+              )
             )
           else:
             ref = event.get("ref", "")
             tag_name = ref.split("/")[-1] if ref else ""
             html_url = f"https://github.com/{repository}/releases/tag/{tag_name}"
-            message = (
-              "🏷️ New tag pushed\n"
-              f"Repository: {repository}\n"
-              f"Tag: {tag_name}\n"
-              f"Pushed by: {actor}\n"
-              f"Details: {html_url}"
+            # Compose the tag notification text in a deterministic order for clarity and reliability.
+            message = "".join(
+              (
+                "🏷️ New tag pushed\n",
+                f"Repository: {repository}\n",
+                f"Tag: {tag_name}\n",
+                f"Pushed by: {actor}\n",
+                f"Details: {html_url}",
+              )
             )
 
           # Persist the message to the step output for downstream usage.


### PR DESCRIPTION
## Summary
- build Telegram release message strings with join to avoid tuple outputs
- preserve notification formatting while guaranteeing GitHub Actions compatibility

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7d8e302c4833082ab178ddb89d7a8