### PR TITLE
Change publish workflow trigger to tag pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Release — Build and Publish to npm
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
@@ -39,8 +39,6 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        if: ${{ github.event_name == 'release' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
-


### PR DESCRIPTION
Updated workflow to trigger on version tag pushes instead of releases.