### PR TITLE
update from main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,8 @@ name: Release — Build and Publish to npm
 on:
   push:
     tags:
-      - 'v*'   # chạy khi push tag dạng v*
+      - 'v*'
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -21,19 +22,17 @@ jobs:
         with:
           node-version: 20.x
           registry-url: https://registry.npmjs.org
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
+          run_install: false
 
-      - name: Verify pnpm
-        run: pnpm --version
-
-      - name: Install dependencies
+      - name: Install dependencies (with cache)
         run: pnpm install --frozen-lockfile
+        env:
+          NPM_CONFIG_CACHE: ~/.pnpm-store
 
       - name: Lint
         run: pnpm run lint
@@ -44,4 +43,4 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: pnpm publish --access public


### PR DESCRIPTION
This pull request updates the npm publish workflow in `.github/workflows/publish.yml` to improve dependency management and publishing reliability. The main changes include switching from `npm` to `pnpm` for publishing, optimizing dependency installation with caching, and enabling manual workflow triggers.

**Workflow improvements:**

* Added support for manual workflow dispatch, allowing the publish workflow to be triggered directly from the GitHub UI.

**Dependency management and caching:**

* Removed the explicit `pnpm` cache setup in the `actions/setup-node` step and moved cache configuration to the `pnpm install` step using the `NPM_CONFIG_CACHE` environment variable for more reliable caching.
* Disabled automatic dependency installation in the `pnpm/action-setup` step by setting `run_install: false`, ensuring dependencies are installed explicitly in a later step.
* Combined dependency installation and caching into a single step for improved efficiency and clarity.

**Publishing process:**

* Changed the publish command from `npm publish` to `pnpm publish` to ensure consistency with the package manager used for installation.