### PR TITLE
Adds VastAI account actions and fixes publish workflow

### DIFF
--- a/nodes/VastAiNode/Accounts/CreateEnvVar.ts
+++ b/nodes/VastAiNode/Accounts/CreateEnvVar.ts
@@ -1,0 +1,4 @@
+export const createEnvVarParams = [
+	{ name: 'Key', value: 'key' },
+	{ name: 'Value', value: 'value' },
+];

--- a/nodes/VastAiNode/Accounts/CreateSSHKey.ts
+++ b/nodes/VastAiNode/Accounts/CreateSSHKey.ts
@@ -1,0 +1,3 @@
+export const createSshKeyParams = [
+	{ name: 'SSH Key', value: 'ssh_key' },
+];

--- a/nodes/VastAiNode/Accounts/CreateSubaccount.ts
+++ b/nodes/VastAiNode/Accounts/CreateSubaccount.ts
@@ -1,0 +1,9 @@
+export const createSubaccountParams: Array<{ name: string; value: string }> = [
+	{ name: 'Email', value: 'email' },
+	{ name: 'Username', value: 'username' },
+	{ name: 'Password', value: 'password' },
+	{ name: 'Host Only', value: 'host_only' },
+	{ name: 'Parent ID', value: 'parent_id' },
+	{ name: 'SSH Key', value: 'ssh_key' },
+	{ name: 'Captcha', value: 'captcha' },
+];

--- a/nodes/VastAiNode/Accounts/DeleteAPIKey.ts
+++ b/nodes/VastAiNode/Accounts/DeleteAPIKey.ts
@@ -1,0 +1,3 @@
+export const deleteApiKeyParams = [
+	{ name: 'ID', value: 'id' },
+];

--- a/nodes/VastAiNode/Accounts/DeleteEnvVar.ts
+++ b/nodes/VastAiNode/Accounts/DeleteEnvVar.ts
@@ -1,0 +1,3 @@
+export const deleteEnvVarParams = [
+	{ name: 'Key', value: 'key' },
+];

--- a/nodes/VastAiNode/Accounts/DeleteSSHKey.ts
+++ b/nodes/VastAiNode/Accounts/DeleteSSHKey.ts
@@ -1,0 +1,3 @@
+export const deleteSshKeyParams = [
+	{ name: 'ID', value: 'id' },
+];

--- a/nodes/VastAiNode/Accounts/ResetAPIKey.ts
+++ b/nodes/VastAiNode/Accounts/ResetAPIKey.ts
@@ -1,0 +1,3 @@
+export const resetApiKeyParams = [
+	{ name: 'Client ID', value: 'client_id' },
+];

--- a/nodes/VastAiNode/Accounts/SetUser.ts
+++ b/nodes/VastAiNode/Accounts/SetUser.ts
@@ -1,0 +1,5 @@
+export const setUserParams = [
+	{ name: 'Normalized Email', value: 'normalized_email' },
+	{ name: 'Username', value: 'username' },
+	{ name: 'Full Name', value: 'fullname' },
+];

--- a/nodes/VastAiNode/Accounts/ShowAPIKey.ts
+++ b/nodes/VastAiNode/Accounts/ShowAPIKey.ts
@@ -1,0 +1,3 @@
+export const showAPIKeyParams = [
+	{ name: 'ID', value: 'id' },
+];

--- a/nodes/VastAiNode/Accounts/ShowIpaddrs.ts
+++ b/nodes/VastAiNode/Accounts/ShowIpaddrs.ts
@@ -1,0 +1,3 @@
+export const showIpaddrsParams = [
+	{ name: 'User ID', value: 'user_id' },
+];

--- a/nodes/VastAiNode/Accounts/ShowTeamRole.ts
+++ b/nodes/VastAiNode/Accounts/ShowTeamRole.ts
@@ -1,0 +1,3 @@
+export const showTeamRoleParams = [
+	{ name: 'ID', value: 'id' },
+];

--- a/nodes/VastAiNode/Accounts/TransferCredit.ts
+++ b/nodes/VastAiNode/Accounts/TransferCredit.ts
@@ -1,0 +1,6 @@
+export const transferCreditParams = [
+	{ name: 'Recipient', value: 'recipient' },
+	{ name: 'Amount', value: 'amount' },
+	{ name: 'Client ID', value: 'client_id' },
+	{ name: 'API Key ID', value: 'apikey_id' },
+];

--- a/nodes/VastAiNode/Accounts/UpdateEnvVar.ts
+++ b/nodes/VastAiNode/Accounts/UpdateEnvVar.ts
@@ -1,0 +1,4 @@
+export const updateEnvVarParams = [
+	{ name: 'Key', value: 'key' },
+	{ name: 'Value', value: 'value' },
+];

--- a/nodes/VastAiNode/Accounts/UpdateSSHKey.ts
+++ b/nodes/VastAiNode/Accounts/UpdateSSHKey.ts
@@ -1,0 +1,4 @@
+export const updateSshKeyParams = [
+	{ name: 'ID', value: 'id' },
+	{ name: 'SSH Key', value: 'ssh_key' },
+];

--- a/nodes/VastAiNode/VastAiNode.node.ts
+++ b/nodes/VastAiNode/VastAiNode.node.ts
@@ -49,6 +49,20 @@ import { setMinBidParams } from './Machines/setMinBid';
 import { showMachinesParams } from './Machines/ShowMachines';
 import { unlistMachineParams } from './Machines/UnlistMachine';
 import { createApiKeyParams } from './Accounts/CreateApiKey';
+import { createEnvVarParams } from './Accounts/CreateEnvVar';
+import { deleteEnvVarParams } from './Accounts/DeleteEnvVar';
+import { updateEnvVarParams } from './Accounts/UpdateEnvVar';
+import { showAPIKeyParams } from './Accounts/ShowAPIKey';
+import { deleteApiKeyParams } from './Accounts/DeleteAPIKey';
+import { createSshKeyParams } from './Accounts/CreateSSHKey';
+import { createSubaccountParams } from './Accounts/CreateSubaccount';
+import { setUserParams } from './Accounts/SetUser';
+import { deleteSshKeyParams } from './Accounts/DeleteSSHKey';
+import { updateSshKeyParams } from './Accounts/UpdateSSHKey';
+import { resetApiKeyParams } from './Accounts/ResetAPIKey';
+import { showIpaddrsParams } from './Accounts/ShowIpaddrs';
+import { showTeamRoleParams } from './Accounts/ShowTeamRole';
+import { transferCreditParams } from './Accounts/TransferCredit';
 
 interface ApiEndpoint {
 	endpoint: string;
@@ -185,26 +199,26 @@ export class VastAiNode implements INodeType {
 					case 'accounts':
 						return [
 							{ name: 'Create API Key', value: 'create_api_key_post' },
-							// { name: 'Create Env Var', value: 'create_env_var_post' },
-							// { name: 'Create SSH Key', value: 'create_ssh_key_post' },
-							// { name: 'Create Subaccount', value: 'create_subaccount_post' },
-							// { name: 'Delete API Key', value: 'delete_api_key_delete' },
-							// { name: 'Delete Env Var', value: 'delete_env_var_delete' },
-							// { name: 'Delete SSH Key', value: 'delete_ssh_key_delete' },
-							// { name: 'Reset API Key', value: 'reset_api_key_put' },
-							// { name: 'Set User', value: 'set_user_put' },
+							{ name: 'Create Env Var', value: 'create_env_var_post' },
+							{ name: 'Create SSH Key', value: 'create_ssh_key_post' },
+							{ name: 'Create Subaccount', value: 'create_subaccount_post' },
+							{ name: 'Delete API Key', value: 'delete_api_key_delete' },
+							{ name: 'Delete Env Var', value: 'delete_env_var_delete' },
+							{ name: 'Delete SSH Key', value: 'delete_ssh_key_delete' },
+							{ name: 'Reset API Key', value: 'reset_api_key_put' },
+							{ name: 'Set User', value: 'set_user_put' },
 							{ name: 'Show API Keys', value: 'show_api_keys_get' },
-							// { name: 'Show API Key', value: 'show_api_key_get' },
+							{ name: 'Show API Key', value: 'show_api_key_get' },
 							{ name: 'Show Connections', value: 'show_connections_get' },
 							{ name: 'Show Env Vars', value: 'show_env_vars_get' },
-							// { name: 'Show Ipaddrs', value: 'show_ipaddrs_get' },
-							// { name: 'Show SSH Keys', value: 'acc_show_ssh_keys_get' },
+							{ name: 'Show Ipaddrs', value: 'show_ipaddrs_get' },
+							{ name: 'Show SSH Keys', value: 'acc_show_ssh_keys_get' },
 							{ name: 'Show Subaccounts', value: 'show_subaccounts_get' },
-							// { name: 'Show Team Role', value: 'show_team_role_get' },
+							{ name: 'Show Team Role', value: 'show_team_role_get' },
 							{ name: 'Show User', value: 'show_user_get' },
-							// { name: 'Transfer Credit', value: 'transfer_credit_put' },
-							// { name: 'Update Env Var', value: 'update_env_var_put' },
-							// { name: 'Update SSH Key', value: 'update_ssh_key_put' },
+							{ name: 'Transfer Credit', value: 'transfer_credit_put' },
+							{ name: 'Update Env Var', value: 'update_env_var_put' },
+							{ name: 'Update SSH Key', value: 'update_ssh_key_put' },
 						];
 					case 'serverless':
 						return [
@@ -332,43 +346,43 @@ export class VastAiNode implements INodeType {
 					case 'show_api_keys_get':
 						return [];
 					case 'create_env_var_post':
-						return [];
+						return createEnvVarParams;
 					case 'delete_env_var_delete':
-						return [];
+						return deleteEnvVarParams;
 					case 'show_env_vars_get':
 						return [];
 					case 'update_env_var_put':
-						return [];
+						return updateEnvVarParams;
 					case 'create_ssh_key_post':
-						return [];
+						return createSshKeyParams;
 					case 'acc_show_ssh_keys_get':
 						return [];
 					case 'create_subaccount_post':
-						return [];
+						return createSubaccountParams;
 					case 'set_user_put':
-						return [];
+						return setUserParams;
 					case 'delete_api_key_delete':
-						return [];
+						return deleteApiKeyParams;
 					case 'show_api_key_get':
-						return [];
+						return showAPIKeyParams;
 					case 'delete_ssh_key_delete':
-						return [];
+						return deleteSshKeyParams;
 					case 'update_ssh_key_put':
-						return [];
+						return updateSshKeyParams;
 					case 'reset_api_key_put':
-						return [];
+						return resetApiKeyParams;
 					case 'show_connections_get':
 						return [];
 					case 'show_ipaddrs_get':
-						return [];
+						return showIpaddrsParams;
 					case 'show_subaccounts_get':
 						return [];
 					case 'show_team_role_get':
-						return [];
+						return showTeamRoleParams;
 					case 'show_user_get':
 						return [];
 					case 'transfer_credit_put':
-						return [];
+						return transferCreditParams;
 
 					// Serverless cases
 					case 'create_autogroup_post':
@@ -468,26 +482,26 @@ export class VastAiNode implements INodeType {
 		const apisMap: Record<string, ApiEndpoint> = {
 			// Accounts
 			"create_api_key_post": { endpoint: "/auth/apikeys/", method: "POST" },
-			"create_env_var_post": { endpoint: "", method: "POST" },
-			"create_ssh_key_post": { endpoint: "", method: "POST" },
-			"create_subaccount_post": { endpoint: "", method: "POST" },
-			"delete_api_key_delete": { endpoint: "", method: "DELETE" },
-			"delete_env_var_delete": { endpoint: "", method: "DELETE" },
-			"delete_ssh_key_delete": { endpoint: "", method: "DELETE" },
-			"reset_api_key_put": { endpoint: "", method: "PUT" },
-			"set_user_put": { endpoint: "", method: "PUT" },
-			"show_api_key_get": { endpoint: "", method: "GET" },
+			"create_env_var_post": { endpoint: "/secrets/", method: "POST" },
+			"create_ssh_key_post": { endpoint: "/ssh/", method: "POST" },
+			"create_subaccount_post": { endpoint: "/users/", method: "POST" },
+			"delete_api_key_delete": { endpoint: "/auth/apikeys/{id}/", method: "DELETE" },
+			"delete_env_var_delete": { endpoint: "/secrets/", method: "DELETE" },
+			"delete_ssh_key_delete": { endpoint: "/ssh/{id}/", method: "DELETE" },
+			"reset_api_key_put": { endpoint: "/commands/reset_apikey/", method: "PUT" },
+			"set_user_put": { endpoint: "/users/", method: "PUT" },
+			"show_api_key_get": { endpoint: "/auth/apikeys/{id}/", method: "GET" },
 			"show_api_keys_get": { endpoint: "/auth/apikeys/", method: "GET" },
 			"show_connections_get": { endpoint: "/users/cloud_integrations/", method: "GET" },
 			"show_env_vars_get": { endpoint: "/secrets/", method: "GET" },
-			"show_ipaddrs_get": { endpoint: "", method: "GET" },
-			"acc_show_ssh_keys_get": { endpoint: "", method: "GET" },
+			"show_ipaddrs_get": { endpoint: "/users/{user_id}/ipaddrs/", method: "GET" },
+			"acc_show_ssh_keys_get": { endpoint: "/ssh/", method: "GET" },
 			"show_subaccounts_get": { endpoint: "/subaccounts/", method: "GET" },
-			"show_team_role_get": { endpoint: "", method: "GET" },
+			"show_team_role_get": { endpoint: "/team/roles/{id}/", method: "GET" },
 			"show_user_get": { endpoint: "/users/current/", method: "GET" },
-			"transfer_credit_put": { endpoint: "", method: "PUT" },
-			"update_env_var_put": { endpoint: "", method: "PUT" },
-			"update_ssh_key_put": { endpoint: "", method: "PUT" },
+			"transfer_credit_put": { endpoint: "/commands/transfer_credit/", method: "PUT" },
+			"update_env_var_put": { endpoint: "/secrets/", method: "PUT" },
+			"update_ssh_key_put": { endpoint: "/ssh/{id}/", method: "PUT" },
 
 			// Billing
 			"search_invoices_get": { endpoint: "/invoices", method: "GET" },
@@ -897,6 +911,61 @@ export class VastAiNode implements INodeType {
 								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: machine_id', { itemIndex });
 							}
 							requestOptions.url = requestOptions.url.replace('{machine_id}', encodeURIComponent(String(machine_id)));
+							break;
+						}
+					case 'show_api_key_get':
+						{
+							let id = queryParams.id;
+							if (id == null || id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{id}', encodeURIComponent(String(id)));
+							break;
+						}
+					case 'delete_api_key_delete':
+						{
+							let id = requestBody.id;
+							if (id == null || id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{id}', encodeURIComponent(String(id)));
+							break;
+						}
+					case 'delete_ssh_key_delete':
+						{
+							let id = requestBody.id;
+							if (id == null || id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{id}', encodeURIComponent(String(id)));
+							break;
+						}
+					case 'update_ssh_key_put':
+						{
+							const {id, ...rest} = requestBody;
+							if (id == null || id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{id}', encodeURIComponent(String(id)));
+							requestOptions.body = rest;
+							break;
+						}
+					case 'show_ipaddrs_get':
+						{
+							const user_id = queryParams.user_id;
+							if (user_id == null || user_id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: user_id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{user_id}', encodeURIComponent(String(user_id)));
+							break;
+						}
+					case 'show_team_role_get':
+						{
+							const id = queryParams.id;
+							if (id == null || id === '') {
+								throw new NodeOperationError(this.getNode(), 'Missing required path parameter: id', { itemIndex });
+							}
+							requestOptions.url = requestOptions.url.replace('{id}', encodeURIComponent(String(id)));
 							break;
 						}
 					default:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 onlyBuiltDependencies:
   - eslint-plugin-n8n-nodes-base
+packages:
+  - .


### PR DESCRIPTION
### Summary

Adds new actions for VastAI accounts, including creating/deleting API keys, SSH keys, environment variables, and subaccounts. It also fixes the publish workflow to use `pnpm publish` and configures caching.

### Motivation

This change is needed to expand the functionality of the VastAI node by providing more actions related to account management. The publish workflow is updated to use `pnpm` for publishing to improve consistency and reliability.

### Changes

-   Adds new files for various VastAI account actions, defining input parameters.
-   Modifies `VastAiNode.node.ts` to include new account actions in the node's functionality, providing corresponding API endpoints.
-   Updates `.github/workflows/publish.yml` to:
    -   Add `workflow_dispatch` trigger.
    -   Use `pnpm publish` instead of `npm publish`.
    -   Configures `pnpm` for installation with cache.
    -   Removes redundant pnpm version check.
-   Includes root package in workspace to be able to build the package in github actions.

### Testing

-   [ ] Unit tests
-   [ ] Manual testing
-   [ ] Integration tests

### Related Issues