### PR TITLE
chore: bumps package version to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-vast.ai",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Using the Vast.AI API in an n8n environment.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
This commit updates the package version from 1.0.5 to 1.0.6.

This change is necessary to reflect updates to the package and
ensure proper versioning for future releases.
